### PR TITLE
Add basic peer implementation and tests

### DIFF
--- a/cmd/p2p/main.go
+++ b/cmd/p2p/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+
+	"example.com/p2p/pkg/peer"
+)
+
+func main() {
+	addr := flag.String("addr", "localhost:0", "listen address")
+	flag.Parse()
+
+	p := peer.New(*addr)
+	ln, err := net.Listen("tcp", p.Addr)
+	if err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+	fmt.Printf("Peer ID %s listening on %s\n", p.ID, ln.Addr().String())
+	select {}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module example.com/p2p
+
+go 1.23.8

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -1,0 +1,26 @@
+package message
+
+import (
+	"encoding/json"
+)
+
+// Message represents a chat message exchanged between peers.
+type Message struct {
+	SenderID   string `json:"sender_id"`
+	SequenceNo int    `json:"sequence_no"`
+	Payload    string `json:"payload"`
+}
+
+// Marshal encodes the message as JSON bytes.
+func (m *Message) Marshal() ([]byte, error) {
+	return json.Marshal(m)
+}
+
+// Unmarshal decodes JSON bytes into the message.
+func Unmarshal(data []byte) (*Message, error) {
+	var msg Message
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}

--- a/pkg/message/message_test.go
+++ b/pkg/message/message_test.go
@@ -1,0 +1,18 @@
+package message
+
+import "testing"
+
+func TestMarshalUnmarshal(t *testing.T) {
+	original := &Message{SenderID: "id1", SequenceNo: 1, Payload: "hello"}
+	data, err := original.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	decoded, err := Unmarshal(data)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.SenderID != original.SenderID || decoded.SequenceNo != original.SequenceNo || decoded.Payload != original.Payload {
+		t.Fatalf("decoded message does not match original")
+	}
+}

--- a/pkg/peer/peer.go
+++ b/pkg/peer/peer.go
@@ -1,0 +1,58 @@
+package peer
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net"
+	"sync"
+)
+
+// Peer represents a node in the chat network.
+type Peer struct {
+	ID   string
+	Addr string
+
+	mu    sync.Mutex
+	conns map[string]net.Conn
+}
+
+// New creates a new peer listening on the given address.
+func New(addr string) *Peer {
+	return &Peer{
+		ID:    randomID(),
+		Addr:  addr,
+		conns: make(map[string]net.Conn),
+	}
+}
+
+func randomID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
+}
+
+// AddConn adds a connection to another peer.
+func (p *Peer) AddConn(id string, conn net.Conn) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.conns[id] = conn
+}
+
+// RemoveConn removes a connection.
+func (p *Peer) RemoveConn(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if c, ok := p.conns[id]; ok {
+		c.Close()
+		delete(p.conns, id)
+	}
+}
+
+// Connections returns the number of active connections.
+func (p *Peer) Connections() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.conns)
+}

--- a/pkg/peer/peer_test.go
+++ b/pkg/peer/peer_test.go
@@ -1,0 +1,29 @@
+package peer
+
+import (
+	"net"
+	"testing"
+)
+
+func TestNewPeer(t *testing.T) {
+	p := New("localhost:0")
+	if p.ID == "" {
+		t.Fatal("expected peer ID to be set")
+	}
+}
+
+func TestAddRemoveConn(t *testing.T) {
+	p := New("localhost:0")
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	p.AddConn("peer2", c1)
+	if p.Connections() != 1 {
+		t.Fatalf("expected 1 connection, got %d", p.Connections())
+	}
+	p.RemoveConn("peer2")
+	if p.Connections() != 0 {
+		t.Fatalf("expected 0 connections, got %d", p.Connections())
+	}
+}


### PR DESCRIPTION
## Summary
- create go module
- implement `Message` with JSON helpers
- implement `Peer` with connection management
- add minimal command-line peer
- test message marshaling and peer connections

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683fd6e4147c832c9ebab00b61d63df7