### PR TITLE
Add broadcast function to peers

### DIFF
--- a/pkg/peer/peer_test.go
+++ b/pkg/peer/peer_test.go
@@ -3,6 +3,8 @@ package peer
 import (
 	"net"
 	"testing"
+
+	"example.com/p2p/pkg/message"
 )
 
 func TestNewPeer(t *testing.T) {
@@ -25,5 +27,45 @@ func TestAddRemoveConn(t *testing.T) {
 	p.RemoveConn("peer2")
 	if p.Connections() != 0 {
 		t.Fatalf("expected 0 connections, got %d", p.Connections())
+	}
+}
+
+func TestBroadcast(t *testing.T) {
+	p := New("localhost:0")
+	c1a, c1b := net.Pipe()
+	c2a, c2b := net.Pipe()
+	defer c1a.Close()
+	defer c1b.Close()
+	defer c2a.Close()
+	defer c2b.Close()
+
+	p.AddConn("peer1", c1a)
+	p.AddConn("peer2", c2a)
+
+	msg := &message.Message{SenderID: p.ID, SequenceNo: 1, Payload: "hi"}
+
+	done := make(chan *message.Message, 2)
+	go func() {
+		buf := make([]byte, 512)
+		n, _ := c1b.Read(buf)
+		m, _ := message.Unmarshal(buf[:n])
+		done <- m
+	}()
+	go func() {
+		buf := make([]byte, 512)
+		n, _ := c2b.Read(buf)
+		m, _ := message.Unmarshal(buf[:n])
+		done <- m
+	}()
+
+	if err := p.Broadcast(msg); err != nil {
+		t.Fatalf("broadcast: %v", err)
+	}
+
+	m1 := <-done
+	m2 := <-done
+
+	if m1.Payload != msg.Payload || m2.Payload != msg.Payload {
+		t.Fatalf("expected payload %s, got %s and %s", msg.Payload, m1.Payload, m2.Payload)
 	}
 }


### PR DESCRIPTION
## Summary
- support broadcasting messages to connected peers
- test the broadcast logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683fd9aa2558832cb61f652b1e6f0ef1