### PR TITLE
Add deduplication helper

### DIFF
--- a/pkg/dedup/dedup.go
+++ b/pkg/dedup/dedup.go
@@ -1,0 +1,35 @@
+package dedup
+
+// Deduper tracks recently seen IDs to avoid processing duplicates.
+type Deduper struct {
+	capacity int
+	set      map[string]struct{}
+	order    []string
+}
+
+// New creates a Deduper with the given capacity.
+func New(capacity int) *Deduper {
+	if capacity <= 0 {
+		capacity = 1
+	}
+	return &Deduper{
+		capacity: capacity,
+		set:      make(map[string]struct{}),
+	}
+}
+
+// Seen reports whether id has been seen before. If not, it records the id and
+// returns false. Once the capacity is exceeded, the oldest ID is evicted.
+func (d *Deduper) Seen(id string) bool {
+	if _, ok := d.set[id]; ok {
+		return true
+	}
+	d.set[id] = struct{}{}
+	d.order = append(d.order, id)
+	if len(d.order) > d.capacity {
+		oldest := d.order[0]
+		d.order = d.order[1:]
+		delete(d.set, oldest)
+	}
+	return false
+}

--- a/pkg/dedup/dedup_test.go
+++ b/pkg/dedup/dedup_test.go
@@ -1,0 +1,23 @@
+package dedup
+
+import "testing"
+
+func TestDeduper(t *testing.T) {
+	d := New(2)
+	if d.Seen("a") {
+		t.Fatalf("first time 'a' should be unseen")
+	}
+	if !d.Seen("a") {
+		t.Fatalf("second time 'a' should be seen")
+	}
+	if d.Seen("b") {
+		t.Fatalf("first time 'b' should be unseen")
+	}
+	if d.Seen("c") {
+		t.Fatalf("first time 'c' should be unseen")
+	}
+	// 'a' should have been evicted (capacity 2)
+	if d.Seen("a") {
+		t.Fatalf("'a' should have been evicted and be unseen again")
+	}
+}

--- a/pkg/peer/peer_test.go
+++ b/pkg/peer/peer_test.go
@@ -69,3 +69,14 @@ func TestBroadcast(t *testing.T) {
 		t.Fatalf("expected payload %s, got %s and %s", msg.Payload, m1.Payload, m2.Payload)
 	}
 }
+
+func TestSeen(t *testing.T) {
+	p := New("localhost:0")
+	msg := &message.Message{SenderID: "p1", SequenceNo: 1, Payload: "hi"}
+	if p.Seen(msg) {
+		t.Fatalf("first time message should be unseen")
+	}
+	if !p.Seen(msg) {
+		t.Fatalf("second time message should be seen")
+	}
+}


### PR DESCRIPTION
## Summary
- track recently seen message IDs
- integrate deduplication with peer broadcast
- test dedup logic and peer Seen

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683fdbcd3e54832caf1f2b2c608d0240