### PR TITLE
Add unit and integration tests

### DIFF
--- a/pkg/peer/handshake_test.go
+++ b/pkg/peer/handshake_test.go
@@ -1,0 +1,36 @@
+package peer
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"testing"
+)
+
+// TestHandshakeLongID verifies that handshake returns an error when the remote
+// peer sends an ID longer than the allowed limit.
+func TestHandshakeLongID(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := handshake(c1, "local")
+		errCh <- err
+	}()
+
+	// Remote side: read the local ID and respond with an overly long ID.
+	r := bufio.NewReader(c2)
+	if _, err := r.ReadString('\n'); err != nil {
+		t.Fatalf("read id: %v", err)
+	}
+	longID := strings.Repeat("x", 65)
+	// Perform the write in a goroutine so we don't block if the handshake
+	// stops reading after the error condition is triggered.
+	go func() { _, _ = c2.Write([]byte(longID + "\n")) }()
+
+	if err := <-errCh; err == nil {
+		t.Fatal("expected error from long remote id, got nil")
+	}
+}

--- a/pkg/peer/peer_integration_test.go
+++ b/pkg/peer/peer_integration_test.go
@@ -1,0 +1,65 @@
+package peer
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"example.com/p2p/pkg/message"
+)
+
+// TestThreePeerMessaging spins up three peers connected in a line and ensures
+// a broadcast from one end reaches the other end.
+func TestThreePeerMessaging(t *testing.T) {
+	p1 := New("localhost:0")
+	ln1, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen1: %v", err)
+	}
+	defer ln1.Close()
+	go p1.Serve(ln1)
+
+	p2 := New("localhost:0")
+	ln2, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen2: %v", err)
+	}
+	defer ln2.Close()
+	go p2.Serve(ln2)
+
+	p3 := New("localhost:0")
+	ln3, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen3: %v", err)
+	}
+	defer ln3.Close()
+	go p3.Serve(ln3)
+
+	// Connect peers in a chain: p2 <-> p1 and p3 <-> p2
+	if _, err := p2.Connect(ln1.Addr().String()); err != nil {
+		t.Fatalf("p2 connect p1: %v", err)
+	}
+	if _, err := p3.Connect(ln2.Addr().String()); err != nil {
+		t.Fatalf("p3 connect p2: %v", err)
+	}
+
+	// Wait briefly for all connections to establish
+	time.Sleep(100 * time.Millisecond)
+
+	msg := &message.Message{SenderID: p1.ID, SequenceNo: 1, Payload: "hello"}
+	if err := p1.Broadcast(msg); err != nil {
+		t.Fatalf("broadcast: %v", err)
+	}
+
+	// Expect p2 and p3 to each receive the message once
+	for _, p := range []*Peer{p2, p3} {
+		select {
+		case m := <-p.Messages:
+			if m.Payload != msg.Payload {
+				t.Fatalf("expected payload %s got %s", msg.Payload, m.Payload)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for message")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add integration test for multi-peer messaging
- add handshake error test for long IDs

## Testing
- `go test ./pkg/peer -run TestHandshakeLongID -v`
- `go test ./pkg/peer -run TestThreePeerMessaging -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684096683afc832c9dcf4b24a0df53d6