### PR TITLE
Add missing unit and integration tests

### DIFF
--- a/pkg/dedup/dedup_test.go
+++ b/pkg/dedup/dedup_test.go
@@ -21,3 +21,15 @@ func TestDeduper(t *testing.T) {
 		t.Fatalf("'a' should have been evicted and be unseen again")
 	}
 }
+func TestDeduperCapacityOne(t *testing.T) {
+	d := New(0)
+	if d.Seen("a") {
+		t.Fatalf("first time 'a' should be unseen")
+	}
+	if d.Seen("b") {
+		t.Fatalf("first time 'b' should be unseen")
+	}
+	if d.Seen("a") {
+		t.Fatalf("'a' should have been evicted with capacity 1")
+	}
+}

--- a/pkg/message/message_test.go
+++ b/pkg/message/message_test.go
@@ -16,3 +16,9 @@ func TestMarshalUnmarshal(t *testing.T) {
 		t.Fatalf("decoded message does not match original")
 	}
 }
+
+func TestUnmarshalInvalid(t *testing.T) {
+	if _, err := Unmarshal([]byte("{invalid")); err == nil {
+		t.Fatal("expected error from invalid JSON")
+	}
+}

--- a/pkg/peer/disconnect_test.go
+++ b/pkg/peer/disconnect_test.go
@@ -12,8 +12,12 @@ func TestHandleConnRemoteClose(t *testing.T) {
 	a, b := net.Pipe()
 	p.HandleConn("peer2", a)
 	b.Close()
-	time.Sleep(50 * time.Millisecond)
-	if p.Connections() != 0 {
-		t.Fatalf("expected connection to be removed, got %d", p.Connections())
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if p.Connections() == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
+	t.Fatalf("expected connection to be removed, got %d", p.Connections())
 }

--- a/pkg/peer/disconnect_test.go
+++ b/pkg/peer/disconnect_test.go
@@ -1,0 +1,19 @@
+package peer
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// TestHandleConnRemoteClose ensures a closed connection is removed.
+func TestHandleConnRemoteClose(t *testing.T) {
+	p := New("localhost:0")
+	a, b := net.Pipe()
+	p.HandleConn("peer2", a)
+	b.Close()
+	time.Sleep(50 * time.Millisecond)
+	if p.Connections() != 0 {
+		t.Fatalf("expected connection to be removed, got %d", p.Connections())
+	}
+}

--- a/pkg/peer/handshake_test.go
+++ b/pkg/peer/handshake_test.go
@@ -34,3 +34,17 @@ func TestHandshakeLongID(t *testing.T) {
 		t.Fatal("expected error from long remote id, got nil")
 	}
 }
+
+func TestHandshakeRemoteClose(t *testing.T) {
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := handshake(c1, "local")
+		errCh <- err
+	}()
+	c2.Close()
+	if err := <-errCh; err == nil {
+		t.Fatal("expected error from closed connection")
+	}
+}

--- a/pkg/peer/peer_integration_test.go
+++ b/pkg/peer/peer_integration_test.go
@@ -63,3 +63,34 @@ func TestThreePeerMessaging(t *testing.T) {
 		}
 	}
 }
+
+// TestBroadcastNoLoop verifies that a message broadcast does not bounce back to the sender.
+func TestBroadcastNoLoop(t *testing.T) {
+	p1 := New("localhost:0")
+	p2 := New("localhost:0")
+
+	c1, c2 := net.Pipe()
+	p1.HandleConn(p2.ID, c1)
+	p2.HandleConn(p1.ID, c2)
+
+	msg := &message.Message{SenderID: p1.ID, SequenceNo: 1, Payload: "hi"}
+	if err := p1.Broadcast(msg); err != nil {
+		t.Fatalf("broadcast: %v", err)
+	}
+
+	select {
+	case m := <-p2.Messages:
+		if m.Payload != msg.Payload {
+			t.Fatalf("expected payload %s got %s", msg.Payload, m.Payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+
+	select {
+	case m := <-p1.Messages:
+		t.Fatalf("unexpected looped message: %v", m)
+	case <-time.After(100 * time.Millisecond):
+		// ok - no message received
+	}
+}

--- a/pkg/peer/peer_integration_test.go
+++ b/pkg/peer/peer_integration_test.go
@@ -43,8 +43,13 @@ func TestThreePeerMessaging(t *testing.T) {
 		t.Fatalf("p3 connect p2: %v", err)
 	}
 
-	// Wait briefly for all connections to establish
-	time.Sleep(100 * time.Millisecond)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if p1.Connections() == 1 && p2.Connections() == 2 && p3.Connections() == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	msg := &message.Message{SenderID: p1.ID, SequenceNo: 1, Payload: "hello"}
 	if err := p1.Broadcast(msg); err != nil {

--- a/pkg/peer/peer_test.go
+++ b/pkg/peer/peer_test.go
@@ -136,7 +136,13 @@ func TestConnectServe(t *testing.T) {
 		t.Fatalf("connect: %v", err)
 	}
 
-	// give some time for connection to register
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if p1.Connections() == 1 && p2.Connections() == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	if p1.Connections() != 1 || p2.Connections() != 1 {
 		t.Fatalf("expected both peers to have 1 connection")
 	}


### PR DESCRIPTION
## Summary
- extend deduper tests for capacity=0
- add message unmarshalling error test
- add handshake remote close test
- add integration test ensuring broadcasts do not loop back
- verify closed connections are removed

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840aa0a3f54832c9c3a1f04a85bb396